### PR TITLE
Bug Fix - Incorrect Guess Reset

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -17,6 +17,7 @@ app.get('/getInitialString', (req, res) => {
     .get(`http://app.linkedin-reach.io/words?start=${randomInt}&count=1`)
     .then(({ data }) => {
       charactersArray = new Array(data.length);
+      incorrectGuesses = [];
       secretWord = data;
       charactersArray.fill('_');
       res.status(200).send({ charactersArray, data });


### PR DESCRIPTION
This PR fixes a bug where the incorrectGuesses array was not being reset if the user refreshed the page randomly. Added resetting the array to an empty array server side everytime a new word is retrieved from the API.