### PR TITLE
Fix bug where isWinner was not reset on game reset

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -84,6 +84,7 @@ class App extends Component {
   handleGameRestart = () => {
     this.setState({
       lastGuess: 'null',
+      isWinner: false,
       snackbarIsOpen: false,
       incorrectGuesses: [],
       showEndOfGameModal: false


### PR DESCRIPTION
This PR fixes a bug where the isWinner state was not reset on a game reset.